### PR TITLE
Add protected user listing endpoints

### DIFF
--- a/services/auth/app/api/__init__.py
+++ b/services/auth/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API package for versioned routes."""

--- a/services/auth/app/api/v1/__init__.py
+++ b/services/auth/app/api/v1/__init__.py
@@ -1,0 +1,1 @@
+"""Version 1 API routes."""

--- a/services/auth/app/api/v1/user_routes.py
+++ b/services/auth/app/api/v1/user_routes.py
@@ -1,0 +1,38 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.security import get_current_user
+from app.dependencies import get_db
+from app.models.user import User
+from app.schemas.auth import UserResponse
+from app.services.user_service import UserService
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[UserResponse])
+def get_users(
+    current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
+):
+    user_service = UserService(db)
+    return user_service.list_users(current_user)
+
+
+@router.get("/active", response_model=List[UserResponse])
+def get_active_users(
+    current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
+):
+    user_service = UserService(db)
+    return user_service.list_active_users(current_user)
+
+
+@router.get("/roles/{role_id}", response_model=List[UserResponse])
+def get_users_by_role(
+    role_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    user_service = UserService(db)
+    return user_service.list_users_by_role(role_id, current_user)

--- a/services/auth/app/core/security.py
+++ b/services/auth/app/core/security.py
@@ -1,0 +1,65 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.dependencies import get_db
+from app.models.audit_log import AuditLog
+from app.models.user import User
+from app.repository import audit_log_repository, user_repository
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
+        )
+        user_id = payload.get("sub")
+    except JWTError as exc:
+        _log_security_event(db, "token_decode_error", f"Invalid token: {exc}")
+        raise credentials_exception from exc
+
+    if user_id is None:
+        _log_security_event(db, "token_missing_sub", "Token payload missing subject")
+        raise credentials_exception
+
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError) as exc:
+        _log_security_event(db, "token_invalid_sub", f"Invalid subject: {user_id}")
+        raise credentials_exception from exc
+
+    user = user_repository.get_user_by_id(db, user_id_int)
+    if not user:
+        _log_security_event(db, "user_not_found", f"User id {user_id_int} not found")
+        raise credentials_exception
+
+    return user
+
+
+def _log_security_event(db: Session, action: str, message: str) -> None:
+    try:
+        audit_entry = AuditLog(
+            id_user=None,
+            entity="Security",
+            action=action,
+            message=message,
+            state="error",
+        )
+        audit_log_repository.create_audit_log(db, audit_entry)
+        db.commit()
+    except Exception:
+        db.rollback()

--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
-from app.api.v1 import auth_routes
+
+from app.api.v1 import auth_routes, user_routes
 
 app = FastAPI(title="Auth Service")
 
 # incluir rutas
 app.include_router(auth_routes.router, prefix="/api/v1/auth", tags=["auth"])
+app.include_router(user_routes.router, prefix="/api/v1/users", tags=["users"])
 
 @app.get("/health")
 def health_check():

--- a/services/auth/app/repository/user_repository.py
+++ b/services/auth/app/repository/user_repository.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
@@ -13,3 +13,19 @@ def create_user(db: Session, user: User) -> User:
     db.add(user)
     db.flush()
     return user
+
+
+def get_all_users(db: Session) -> List[User]:
+    return db.query(User).all()
+
+
+def get_users_by_status(db: Session, status: str) -> List[User]:
+    return db.query(User).filter(User.status == status).all()
+
+
+def get_users_by_role(db: Session, role_id: int) -> List[User]:
+    return db.query(User).filter(User.id_role == role_id).all()
+
+
+def get_user_by_id(db: Session, user_id: int) -> Optional[User]:
+    return db.query(User).filter(User.id_user == user_id).first()

--- a/services/auth/app/services/user_service.py
+++ b/services/auth/app/services/user_service.py
@@ -1,0 +1,113 @@
+from typing import List
+
+from fastapi import HTTPException, status
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.models.audit_log import AuditLog
+from app.models.user import User
+from app.repository import audit_log_repository, role_repository, user_repository
+
+
+class UserService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def list_users(self, requester: User | None = None) -> List[User]:
+        try:
+            return user_repository.get_all_users(self.db)
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            self._log_error(
+                requester.id_user if requester else None,
+                "list_users_error",
+                f"Database error: {exc}",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retrieve users",
+            ) from exc
+        except Exception as exc:  # pragma: no cover - defensive programming
+            self.db.rollback()
+            self._log_error(
+                requester.id_user if requester else None,
+                "list_users_unexpected_error",
+                f"Unexpected error: {exc}",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Unexpected error while retrieving users",
+            ) from exc
+
+    def list_active_users(self, requester: User | None = None) -> List[User]:
+        try:
+            return user_repository.get_users_by_status(self.db, "active")
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            self._log_error(
+                requester.id_user if requester else None,
+                "list_active_users_error",
+                f"Database error: {exc}",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retrieve active users",
+            ) from exc
+        except Exception as exc:  # pragma: no cover - defensive programming
+            self.db.rollback()
+            self._log_error(
+                requester.id_user if requester else None,
+                "list_active_users_unexpected_error",
+                f"Unexpected error: {exc}",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Unexpected error while retrieving active users",
+            ) from exc
+
+    def list_users_by_role(self, role_id: int, requester: User | None = None) -> List[User]:
+        role = role_repository.get_role_by_id(self.db, role_id)
+        if not role:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Role not found",
+            )
+
+        try:
+            return user_repository.get_users_by_role(self.db, role_id)
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            self._log_error(
+                requester.id_user if requester else None,
+                "list_users_by_role_error",
+                f"Database error: {exc}",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retrieve users by role",
+            ) from exc
+        except Exception as exc:  # pragma: no cover - defensive programming
+            self.db.rollback()
+            self._log_error(
+                requester.id_user if requester else None,
+                "list_users_by_role_unexpected_error",
+                f"Unexpected error: {exc}",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Unexpected error while retrieving users by role",
+            ) from exc
+
+    def _log_error(self, user_id: int | None, action: str, message: str) -> None:
+        try:
+            audit_entry = AuditLog(
+                id_user=user_id,
+                entity="UserService",
+                action=action,
+                message=message,
+                state="error",
+            )
+            audit_log_repository.create_audit_log(self.db, audit_entry)
+            self.db.commit()
+        except Exception:
+            self.db.rollback()


### PR DESCRIPTION
## Summary
- add repository helpers and service layer to fetch users with error logging
- secure API dependency to validate bearer tokens and emit audit logs
- expose authenticated user listing endpoints and register them in the FastAPI app

## Testing
- python -m compileall services/auth/app

------
https://chatgpt.com/codex/tasks/task_e_68d58080d484832b8b288936abac4db8