### PR TITLE
Add Firebase Google auth and refresh token endpoints

### DIFF
--- a/services/auth/app/api/v1/auth_routes.py
+++ b/services/auth/app/api/v1/auth_routes.py
@@ -2,7 +2,14 @@ from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
-from app.schemas.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
+from app.schemas.auth import (
+    GoogleLoginRequest,
+    LoginRequest,
+    RefreshTokenRequest,
+    RegisterRequest,
+    TokenResponse,
+    UserResponse,
+)
 from app.services.auth_service import AuthService
 
 router = APIRouter()
@@ -11,15 +18,49 @@ router = APIRouter()
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
 def register_user(register_data: RegisterRequest, db: Session = Depends(get_db)):
     auth_service = AuthService(db)
-    access_token, user = auth_service.register_user(register_data)
-    return {"access_token": access_token, "token_type": "bearer", "user": user}
+    access_token, refresh_token, user = auth_service.register_user(register_data)
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+        "user": user,
+    }
 
 
 @router.post("/login", response_model=TokenResponse)
 def login_user(login_data: LoginRequest, db: Session = Depends(get_db)):
     auth_service = AuthService(db)
-    access_token, user = auth_service.login_user(login_data)
-    return {"access_token": access_token, "token_type": "bearer", "user": user}
+    access_token, refresh_token, user = auth_service.login_user(login_data)
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+        "user": user,
+    }
+
+
+@router.post("/google", response_model=TokenResponse)
+def login_with_google(payload: GoogleLoginRequest, db: Session = Depends(get_db)):
+    auth_service = AuthService(db)
+    access_token, refresh_token, user = auth_service.login_with_google(payload.id_token)
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+        "user": user,
+    }
+
+
+@router.post("/refresh", response_model=TokenResponse)
+def refresh_token(payload: RefreshTokenRequest, db: Session = Depends(get_db)):
+    auth_service = AuthService(db)
+    access_token, refresh_token, user = auth_service.refresh_tokens(payload.refresh_token)
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+        "user": user,
+    }
 
 
 @router.get("/db-test")

--- a/services/auth/app/core/config.py
+++ b/services/auth/app/core/config.py
@@ -12,6 +12,10 @@ class Settings:
     SECRET_KEY: str = os.getenv("SECRET_KEY", "change_me")
     ALGORITHM: str = os.getenv("ALGORITHM", "HS256")
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+    REFRESH_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_MINUTES", "10080"))
+    FIREBASE_CREDENTIALS_PATH: str = os.getenv("FIREBASE_CREDENTIALS_PATH", "")
+    FIREBASE_PROJECT_ID: str = os.getenv("FIREBASE_PROJECT_ID", "")
+    DEFAULT_SOCIAL_ROLE_ID: int = int(os.getenv("DEFAULT_SOCIAL_ROLE_ID", "1"))
 
 
 @lru_cache()

--- a/services/auth/app/core/firebase.py
+++ b/services/auth/app/core/firebase.py
@@ -1,0 +1,31 @@
+"""Firebase application initialization utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import firebase_admin
+from firebase_admin import credentials
+
+from app.core.config import settings
+
+
+def _build_init_kwargs() -> Dict[str, Any]:
+    init_kwargs: Dict[str, Any] = {}
+    if settings.FIREBASE_PROJECT_ID:
+        init_kwargs["projectId"] = settings.FIREBASE_PROJECT_ID
+    return init_kwargs
+
+
+def get_firebase_app() -> firebase_admin.App:
+    """Return the default Firebase app, initializing it if required."""
+
+    if not firebase_admin._apps:  # type: ignore[attr-defined]
+        if settings.FIREBASE_CREDENTIALS_PATH:
+            cred = credentials.Certificate(settings.FIREBASE_CREDENTIALS_PATH)
+        else:
+            cred = credentials.ApplicationDefault()
+
+        firebase_admin.initialize_app(cred, _build_init_kwargs())
+
+    return firebase_admin.get_app()

--- a/services/auth/app/schemas/auth.py
+++ b/services/auth/app/schemas/auth.py
@@ -72,7 +72,19 @@ class UserResponse(BaseModel):
         from_attributes = True
 
 
+TokenStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
 class TokenResponse(BaseModel):
     access_token: str
+    refresh_token: str
     token_type: str = "bearer"
     user: UserResponse
+
+
+class GoogleLoginRequest(BaseModel):
+    id_token: TokenStr
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: TokenStr

--- a/services/auth/app/services/auth_service.py
+++ b/services/auth/app/services/auth_service.py
@@ -1,16 +1,20 @@
 from datetime import datetime, timedelta
+import secrets
 from typing import Dict, Tuple
 
 from fastapi import HTTPException, status
-from jose import jwt
+from jose import JWTError, jwt
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.core.firebase import get_firebase_app
 from app.models.audit_log import AuditLog
 from app.models.user import User
 from app.repository import audit_log_repository, role_repository, user_repository
 from app.schemas.auth import LoginRequest, RegisterRequest
+
+from firebase_admin import auth as firebase_auth
 
 _pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -19,7 +23,7 @@ class AuthService:
     def __init__(self, db: Session):
         self.db = db
 
-    def register_user(self, register_data: RegisterRequest) -> Tuple[str, User]:
+    def register_user(self, register_data: RegisterRequest) -> Tuple[str, str, User]:
         existing_user = user_repository.get_user_by_email(self.db, register_data.email)
         if existing_user:
             raise HTTPException(
@@ -38,8 +42,13 @@ class AuthService:
 
         new_user = User(
             name=register_data.name,
+            lastname=register_data.lastname,
             email=register_data.email,
             phone=register_data.phone,
+            birthdate=register_data.birthdate,
+            gender=register_data.gender,
+            city=register_data.city,
+            district=register_data.district,
             password_hash=hashed_password,
             id_role=register_data.id_role,
             status="active",
@@ -93,9 +102,11 @@ class AuthService:
         self.db.refresh(new_user)
         access_token = self._create_access_token({"sub": str(new_user.id_user), "email": new_user.email})
 
-        return access_token,new_user
+        refresh_token = self._create_refresh_token({"sub": str(new_user.id_user), "email": new_user.email})
 
-    def login_user(self, login_data: LoginRequest) -> Tuple[str, User]:
+        return access_token, refresh_token, new_user
+
+    def login_user(self, login_data: LoginRequest) -> Tuple[str, str, User]:
         user = user_repository.get_user_by_email(self.db, login_data.email)
         if not user or not _pwd_context.verify(login_data.password, user.password_hash):
             raise HTTPException(
@@ -104,6 +115,7 @@ class AuthService:
             )
 
         access_token = self._create_access_token({"sub": str(user.id_user), "email": user.email})
+        refresh_token = self._create_refresh_token({"sub": str(user.id_user), "email": user.email})
 
         audit_entry = AuditLog(
             id_user=user.id_user,
@@ -132,10 +144,154 @@ class AuthService:
                 detail="Could not complete login"
             ) from exc
 
-        return access_token, user
+        return access_token, refresh_token, user
+
+    def login_with_google(self, id_token: str) -> Tuple[str, str, User]:
+        get_firebase_app()
+
+        try:
+            decoded_token = firebase_auth.verify_id_token(id_token)
+        except firebase_auth.InvalidIdTokenError as exc:  # pragma: no cover - firebase specific
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid Google token",
+            ) from exc
+        except firebase_auth.ExpiredIdTokenError as exc:  # pragma: no cover
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Expired Google token",
+            ) from exc
+        except firebase_auth.RevokedIdTokenError as exc:  # pragma: no cover
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Revoked Google token",
+            ) from exc
+        except Exception as exc:  # pragma: no cover - unexpected firebase errors
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Could not validate Google token",
+            ) from exc
+
+        email = decoded_token.get("email")
+        if not email:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Google token does not contain an email",
+            )
+
+        user = user_repository.get_user_by_email(self.db, email)
+
+        if not user:
+            name = decoded_token.get("name") or "Google User"
+            name_parts = name.split(" ", 1)
+            first_name = name_parts[0]
+            last_name = name_parts[1] if len(name_parts) > 1 else "Google"
+
+            random_password = _pwd_context.hash(secrets.token_urlsafe(32))
+
+            user = User(
+                name=first_name,
+                lastname=last_name,
+                email=email,
+                phone=decoded_token.get("phone_number") or "000000000",
+                birthdate=datetime.utcnow(),
+                gender="unspecified",
+                city=None,
+                district=None,
+                password_hash=random_password,
+                id_role=settings.DEFAULT_SOCIAL_ROLE_ID,
+                status="active",
+            )
+
+            role = role_repository.get_role_by_id(self.db, user.id_role)
+            if not role:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Default role for social login not configured",
+                )
+
+            user_repository.create_user(self.db, user)
+
+            audit_entry = AuditLog(
+                id_user=user.id_user,
+                entity="AuthService",
+                action="google_register",
+                message="User registered via Google",
+                state="active",
+            )
+            audit_log_repository.create_audit_log(self.db, audit_entry)
+
+        access_token = self._create_access_token({"sub": str(user.id_user), "email": user.email})
+        refresh_token = self._create_refresh_token({"sub": str(user.id_user), "email": user.email})
+
+        audit_entry = AuditLog(
+            id_user=user.id_user,
+            entity="AuthService",
+            action="google_login",
+            message="User login with Google",
+            state="active",
+        )
+        audit_log_repository.create_audit_log(self.db, audit_entry)
+
+        try:
+            self.db.commit()
+        except Exception as exc:  # pragma: no cover - database errors
+            self.db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Could not complete Google login",
+            ) from exc
+
+        self.db.refresh(user)
+
+        return access_token, refresh_token, user
+
+    def refresh_tokens(self, refresh_token: str) -> Tuple[str, str, User]:
+        try:
+            payload = jwt.decode(
+                refresh_token,
+                settings.SECRET_KEY,
+                algorithms=[settings.ALGORITHM],
+            )
+        except JWTError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
+            ) from exc
+
+        if payload.get("type") != "refresh":
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
+            )
+
+        user_id = payload.get("sub")
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
+            )
+
+        user = user_repository.get_user_by_id(self.db, int(user_id))
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User not found",
+            )
+
+        access_token = self._create_access_token({"sub": str(user.id_user), "email": user.email})
+        new_refresh_token = self._create_refresh_token({"sub": str(user.id_user), "email": user.email})
+
+        return access_token, new_refresh_token, user
 
     def _create_access_token(self, data: Dict[str, str]) -> str:
         to_encode = data.copy()
         expire = datetime.utcnow() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-        to_encode.update({"exp": expire})
+        to_encode.update({"exp": expire, "type": "access"})
+        return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+    def _create_refresh_token(self, data: Dict[str, str]) -> str:
+        to_encode = data.copy()
+        expire = datetime.utcnow() + timedelta(minutes=settings.REFRESH_TOKEN_EXPIRE_MINUTES)
+        to_encode.update({"exp": expire, "type": "refresh"})
         return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)

--- a/services/auth/requirements.txt
+++ b/services/auth/requirements.txt
@@ -17,6 +17,8 @@ python-jose[cryptography]
 # Cliente HTTP (útil para comunicación entre microservicios)
 httpx
 
+firebase-admin
+
 # Pruebas
 pytest
 pytest-asyncio


### PR DESCRIPTION
## Summary
- integrate Firebase initialization and configuration for Google sign-in support in the auth service
- add refresh token handling and expose Google login and refresh endpoints
- update auth schemas and responses to include refresh tokens and complete user data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9ac7b2ed8832b8a69223300f00949